### PR TITLE
Dispose the presenter before the view

### DIFF
--- a/VSMac-CodeCoverage/CodeCoverage.Pad.Native/PadView.cs
+++ b/VSMac-CodeCoverage/CodeCoverage.Pad.Native/PadView.cs
@@ -61,9 +61,12 @@ namespace CodeCoverage.Pad.Native
 
     protected override void Dispose(bool disposing)
     {
+      if (!disposing)
+      {
+        presenter.Dispose();
+      }
+
       base.Dispose(disposing);
-      if (!disposing) return;
-      presenter.Dispose();
     }
     #endregion
 


### PR DESCRIPTION
This should ensure that the presenter doesn't access anything from the view that would access deallocated memory.

Xamarin.Mac's Dispose `release`s the native handle, which might cause the native memory to be deallocated